### PR TITLE
Added re-authenticaiton for the cookie auth method

### DIFF
--- a/auth_cookie_examples/auth.sh
+++ b/auth_cookie_examples/auth.sh
@@ -6,7 +6,7 @@
 
 set -e
 
-my_uuid=$(uuid)
+my_uuid=$(uuidgen)
 
 cd $(dirname $0)
 

--- a/auth_cookie_examples/auth.sh
+++ b/auth_cookie_examples/auth.sh
@@ -2,22 +2,15 @@
 
 # Note: this is only useful when you want to build an APP that also supports
 #       authentication via cookie. The cookie method loses validity after a
-#       couple of weeks, so so there is probably some refresh method required
-#       which is not detailed here.
+#       couple of weeks, so you need to run reauth.sh some time before that.
 
 set -e
 
-tv_ip=''
-
-# use only A-Z a-z 0-9 for device. Probably. Haven't checked.
-my_device=''
-my_nick=''
-
-my_uuid=$(uuidgen)
-
-
+my_uuid=$(uuid)
 
 cd $(dirname $0)
+
+. ./bravia.cfg
 
 if [ -e 'auth_cookie' ]; then
   echo "There's already an auth_cookie file. Delete the file to continue."
@@ -58,6 +51,7 @@ cookie=$(curl --include --silent -XPOST http://$tv_ip/sony/accessControl --user 
 echo $cookie
 
 echo $cookie > 'auth_cookie'
+echo $my_uuid > 'uuid'
 
 echo;echo
 echo "If everything worked, you should see an auth=<code> line above."
@@ -75,4 +69,4 @@ echo;echo
 ../print_ircc_codes.sh $tv_ip > ircc_command_list
 echo "Available IRCC commands have been saved to 'ircc_command_list'"
 echo
-echo "Run a IRCC command with: ./send_command.sh $tv_ip <IRCC-Code>"
+echo "Run a IRCC command with: ./example_curl.sh $tv_ip <IRCC-Code>"

--- a/auth_cookie_examples/bravia.cfg
+++ b/auth_cookie_examples/bravia.cfg
@@ -1,0 +1,8 @@
+#Config for auth.sh and reauth.sh
+
+# your TV's IP address
+tv_ip=''
+
+# use only A-Z a-z 0-9 for device. Probably. Haven't checked.
+my_device=''
+my_nick=''

--- a/auth_cookie_examples/example_curl.sh
+++ b/auth_cookie_examples/example_curl.sh
@@ -5,8 +5,8 @@
 #       couple of weeks, so so there is probably some refresh method required
 #       which is not detailed here.
 
-if [ "$1" = "" ] || [ "$2" = "" ]; then
-  echo "Usage: $0 <TV_IP> <IRCC_COMMAND>"
+if [ "$1" = "" ]; then
+  echo "Usage: $0 <IRCC_COMMAND>"
   exit 1
 fi
 
@@ -15,6 +15,15 @@ if ! [ -e 'auth_cookie' ]; then
   exit 1
 fi
 
-cmd="<?xml version=\"1.0\"?><s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body><u:X_SendIRCC xmlns:u=\"urn:schemas-sony-com:service:IRCC:1\"><IRCCCode>$2</IRCCCode></u:X_SendIRCC></s:Body></s:Envelope>"
+if ! [ -e 'bravia.cfg' ]; then
+  echo 'bravia.cfg not found.'
+  exit 1
+fi
 
-curl --silent -XPOST http://$ipaddress/sony/IRCC -d "$cmd" -H 'Content-Type: text/xml; charset=UTF-8' -H 'SOAPACTION: "urn:schemas-sony-com:service:IRCC:1#X_SendIRCC"' -H"Cookie: $cookie"
+. ./bravia.cfg
+
+read cookie < auth_cookie
+
+cmd="<?xml version=\"1.0\"?><s:Envelope xmlns:s=\"http://schemas.xmlsoap.org/soap/envelope/\" s:encodingStyle=\"http://schemas.xmlsoap.org/soap/encoding/\"><s:Body><u:X_SendIRCC xmlns:u=\"urn:schemas-sony-com:service:IRCC:1\"><IRCCCode>$1</IRCCCode></u:X_SendIRCC></s:Body></s:Envelope>"
+
+curl --silent -XPOST http://$tv_ip/sony/IRCC -d "$cmd" -H 'Content-Type: text/xml; charset=UTF-8' -H 'SOAPACTION: "urn:schemas-sony-com:service:IRCC:1#X_SendIRCC"' -H"Cookie: $cookie"

--- a/auth_cookie_examples/reauth.sh
+++ b/auth_cookie_examples/reauth.sh
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+# Note: this is only useful when you want to build an APP that also supports
+#       authentication via cookie. You must have run auth.sh and have a saved UUID.
+
+set -e
+
+cd $(dirname $0)
+
+. ./bravia.cfg
+
+if [ ! -e 'uuid' ]; then
+  echo "There is no uuid file. Run auth.sh to generate one."
+  exit 1
+fi
+
+read my_uuid <  'uuid'
+
+if [ "$tv_ip" = "" ] || [ "$my_nick" = "" ] || [ "$my_device" = "" ] || [ "$my_uuid" = "" ]; then
+  echo "Missing configuration data, please edit the script and run it again."
+  exit 2
+fi
+
+data="{\"method\":\"actRegister\",\"params\":[{\"clientid\":\"$my_nick:$my_uuid\",\"nickname\":\"$my_nick ($my_device)\",\"level\":\"private\"},[{\"value\":\"yes\",\"function\":\"WOL\"}]],\"id\":8,\"version\":\"1.0\"}"
+
+echo "-------------------------------"
+echo "Trying to reauthorise and get a new cookie..."
+echo;echo
+
+cookie=$(curl --include --silent -XPOST http://$tv_ip/sony/accessControl -d "$data" | grep -o -E 'auth=([A-Za-z0-9]+)')
+echo $cookie
+
+echo $cookie > 'auth_cookie'
+
+echo;echo
+echo "If everything worked, you should see an auth=<code> line above."
+echo "Your computer is now registered, use it like this:"
+echo
+echo "   curl --cookie \"$cookie\" -XPOST http://$tv_ip/sony/system -d '<JSON STUFF>'"
+
+# Uncomment this to capture the MAC address
+#echo;echo
+#echo "Saving MAC address. This useful to implement Wake-on-LAN"
+#mac=$(arp -a | grep ${tv_ip} | awk '{ print $4 }')
+#echo $mac > 'mac'


### PR DESCRIPTION
Unfortunately I can't use a PSK (my TV doesn't have that menu option) so have to stick with the cookie method.

After much investigation I've found it is possible to re-authenticate and get a new cookie without re-entering a PIN. I've added reauth.sh which does this. It's pretty much just a cut-down version of auth.sh.

Re-authentication requires a consistent UUID so that is now saved to a file like the cookie, and config has been moved to a separate file to avoid duplication.