### PR TITLE
Add send_name.sh script to wrap send_command.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ You need to set your TV to use a pre-shared key.
 
 See `example_goto_media_player.sh` on how to build your automations.
 
+You can also use `send_name.sh` to execute a list of commands with a short delay in between each. This script requires that `BRAVIA_IP` and `BRAVIA_PSK` be set.
+
+```
+BRAVIA_IP=1.2.3.4 BRAVIA_PSK=0.0.0.0 send_name.sh WakeUp Hdmi1
+```
+
+This will wake the TV up and switch the input to HDMI 1. (Tested on Sony A80J.)
+
+Note: The `send_name.sh` script adds a 200ms delay between each command, which might not be sufficient for opening apps like YouTube. Also, because of the limitations of emulating a remote control, not all operations are possible (such as opening a given URL using a specific app.)
+
 Have fun!
 
 ### More detailed explanation

--- a/send_name.sh
+++ b/send_name.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+
+#
+# This is a wrapper around the existing send_command.sh and print_ircc_codes.sh
+# which improves ergonomics a bit by allowing the user to run a command based on 
+# the name of the command name.
+#
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+
+# Ensure jq is installed
+if ! command -v jq &> /dev/null
+then
+    echo "j$(basename $0): jq could not be found. Please install jq." >&2
+    exit 1
+fi
+
+# Check for BRAVIA_IP environment variable
+if [[ -z "${BRAVIA_IP}" ]]; then
+    echo "$(basename $0): BRAVIA_IP environment variable is not set." >&2
+    echo "See https://github.com/breunigs/bravia-auth-and-remote#setup" >&2
+    exit 1
+fi
+
+
+# Check for BRAVIA_PSK environment variable
+if [[ -z "${BRAVIA_PSK}" ]]; then
+    echo "$(basename $0): BRAVIA_PSK environment variable is not set." >&2
+    echo "See https://github.com/breunigs/bravia-auth-and-remote#setup" >&2
+    exit 1
+fi
+
+
+BRAVIA_JSON=$($DIR/print_ircc_codes.sh $BRAVIA_IP)
+
+if [ "$#" -eq 0 ]; then
+  echo "The following commands are available:"
+  echo
+  echo $BRAVIA_JSON | jq -r '.result[1][]["name"]' | column
+  echo
+  echo "Run a command with '$0 COMMAND'."
+
+  exit
+fi
+
+declare -a not_found_names
+
+# Check all names to ensure they exist
+for name in "$@"; do
+  VALUE=$(echo "$BRAVIA_JSON" | jq -r --arg name "$name" '.result[1][] | select(.name == $name).value')
+  if [ "$VALUE" == "" ]; then
+    not_found_names+=("$name")
+  fi
+done
+
+if [ ${#not_found_names[@]} -ne 0 ]; then
+  echo "The following commands are not available: ${not_found_names[*]}" >&2
+  echo "To see all available commands, run $0 without any parameters." >&2
+  exit 1
+fi
+
+# If all names exist, process each one
+for name in "$@"; do
+  VALUE=$(echo "$BRAVIA_JSON" | jq -r --arg name "$name" '.result[1][] | select(.name == $name).value')
+  echo "  $DIR/send_command.sh $BRAVIA_PSK $BRAVIA_IP $VALUE"
+  $DIR/send_command.sh $BRAVIA_IP $BRAVIA_PSK $VALUE
+  # This delay is just a guess, may need to be adjusted
+  sleep 0.2
+done
+


### PR DESCRIPTION
This PR adds a script called `send_name.sh` which wraps the existing scripts with the goal of making the repo a little easier to use.  It uses environment variables for configuration and executes a sequence of commands (or a single command) with a short delay between each.  It also has a decent amount of Usage/Help text to hopefully allow new users to get started quickly.

Demo run:

```
 % BRAVIA_IP=10.1.1.83 BRAVIA_PSK=0000 ./send_name.sh     
The following commands are available:

Num1				Media
Num2				Prev
Num3				Next
Num4				DpadCenter
Num5				CursorUp
Num6				CursorDown
Num7				CursorLeft
Num8				CursorRight
Num9				ShopRemoteControlForcedDynamic
Num0				FlashPlus
Num11				FlashMinus
Num12				DemoMode
Enter				Analog
GGuide				Mode3D
ChannelUp			DigitalToggle
ChannelDown			DemoSurround
VolumeUp			*AD
VolumeDown			AudioMixUp
...

Run a command with './send_name.sh COMMAND'.
j@lounge ~/Code/bravia-auth-and-remote
 % BRAVIA_IP=10.1.1.83 BRAVIA_PSK=0000 ./send_name.sh TvPower
  /home/j/Code/bravia-auth-and-remote/send_command.sh 0000 10.1.1.83 AAAAAQAAAAEAAAAVAw==
✓
```